### PR TITLE
Add flat ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const js = require('@eslint/js');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+
+module.exports = [
+  {
+    ignores: ['dist/**'],
+  },
+  js.configs.recommended,
+  ...tsPlugin.configs['flat/recommended'],
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2018,
+        sourceType: 'module',
+      },
+    },
+    rules: {
+      quotes: ['warn', 'single'],
+      indent: ['warn', 2, { SwitchCase: 1 }],
+      'linebreak-style': ['warn', 'unix'],
+      semi: ['warn', 'always'],
+      'comma-dangle': ['warn', 'always-multiline'],
+      'dot-notation': 'warn',
+      eqeqeq: 'warn',
+      curly: ['warn', 'all'],
+      'brace-style': ['warn'],
+      'prefer-arrow-callback': ['warn'],
+      'max-len': ['warn', 140],
+      'no-console': ['warn'],
+      'lines-between-class-members': ['warn', 'always', { exceptAfterSingleLine: true }],
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- migrate to a flat `eslint.config.js`
- keep lint script using default config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851810849488326b8589bffdcf1c46b

## Summary by Sourcery

Migrate to a flat ESLint configuration using @eslint/js and @typescript-eslint flat preset with custom linting rules, parser settings for TypeScript files, and ignore the dist directory.

Enhancements:
- Migrate to flat ESLint config with JS recommended and TS flat recommended presets and custom rules
- Add TypeScript parser and parserOptions for TS files
- Exclude dist directory from linting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new ESLint configuration to enforce consistent code style and best practices across JavaScript and TypeScript files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->