### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build and Lint
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SmolSoftBoi/homebridge-toshiba-tv/security/code-scanning/1](https://github.com/SmolSoftBoi/homebridge-toshiba-tv/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define workflow-level permissions right after the `on` trigger, setting `contents: read`. This applies to all jobs unless overridden and is sufficient for checkout/build/lint as shown.

Change needed in **`.github/workflows/build.yml`**:
- Insert:
  ```yml
  permissions:
    contents: read
  ```
  between `on: [push, pull_request]` and `jobs:`.

No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add an explicit permissions block to the build workflow to set contents access to read-only for all jobs.